### PR TITLE
fix: add permissions to `auto-author-assign.yml`

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   assign-author:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.] -->
Adding pull request permissions to the `auto-author-assign.yml` github workflow

## Screenshots
Error Message
> ![Screenshot 2025-02-08 at 3 02 32 PM](https://github.com/user-attachments/assets/677df5d5-4bfe-44a9-a461-01b7a2a7ffcb)
