### PR TITLE
Wall jumps

### DIFF
--- a/band_together/entities/player/player.gd
+++ b/band_together/entities/player/player.gd
@@ -24,8 +24,16 @@ func _physics_process(delta):
 	# Add the gravity.
 	if not is_on_floor() and not attached_to_wall:
 		velocity += get_gravity() * delta
-	else:
+	elif is_on_floor_only():
 		double_jump_count = 0
+		
+#double jumps currently reset when the player wall jumps, we can change that. 
+
+	#Handle down, so far only used if the player wants to detach from a wall
+	if Input.is_action_just_pressed("Down") and attached_to_wall:
+		attached_to_wall = false
+		recent_wall = current_wall
+		current_wall = null
 
 	# Handle jump.
 	if Input.is_action_just_pressed("Accept"):
@@ -62,7 +70,7 @@ func _physics_process(delta):
 
 	# Get the input direction and handle the movement/deceleration.
 	var direction = Input.get_axis("Left", "Right")
-	if direction:
+	if direction and not attached_to_wall:
 		if sprite.animation != "walk":
 			sprite.play("walk")  # Play the running animation
 		velocity.x = direction * SPEED

--- a/band_together/entities/player/player.gd
+++ b/band_together/entities/player/player.gd
@@ -6,12 +6,23 @@ const JUMP_VELOCITY: float = -300.0
 var double_jump_count: int = 0
 #region
 
+#keeps track of if the character has attached to the wall
+var attached_to_wall = false
+var used_walljump = 0 # ternary value, it is 0 if the user has not recently used a walljump, -1 if they have
+#recently jumped off a left facing wall, or 1 if they have recently jumped off a right facing wall 
+
+var current_wall = 1
+var recent_wall = 0
+#could also instead keep a variable for the most recently touched wall, so that the player could jump off 
+#of two different walls that face the same direction that are just adjacent to each other. 
+#yea i think im gonna go with that one
+
 @onready var sprite: AnimatedSprite2D = $AnimatedSprite2D
 
 ## Use double hashtags for a "title comment", it looks a lil different!
 func _physics_process(delta):
 	# Add the gravity.
-	if not is_on_floor():
+	if not is_on_floor() and not attached_to_wall:
 		velocity += get_gravity() * delta
 	else:
 		double_jump_count = 0
@@ -20,9 +31,23 @@ func _physics_process(delta):
 	if Input.is_action_just_pressed("Accept"):
 		if is_on_floor():
 			velocity.y = JUMP_VELOCITY
+		
+		elif attached_to_wall:
+			recent_wall = current_wall
+			velocity.y = JUMP_VELOCITY
+			attached_to_wall = false
+			
+		elif is_on_wall():
+			if recent_wall != current_wall:
+				#need to handle it so there can only be one wall jump on a single wall at a time
+				velocity.y = 0
+				#set current wall to the wall the player is currently on 
+				attached_to_wall = true
+				
 		elif double_jump_count == 0:
 			velocity.y = JUMP_VELOCITY
 			double_jump_count += 1
+		
 	if Input.is_action_just_released("Accept") and velocity.y < -60:
 		velocity.y = - 60
 

--- a/band_together/entities/player/player.gd
+++ b/band_together/entities/player/player.gd
@@ -6,28 +6,24 @@ const JUMP_VELOCITY: float = -300.0
 var double_jump_count: int = 0
 #region
 
-#keeps track of if the character has attached to the wall
+#region Walljump info
 var attached_to_wall = false
-var used_walljump = 0 # ternary value, it is 0 if the user has not recently used a walljump, -1 if they have
-#recently jumped off a left facing wall, or 1 if they have recently jumped off a right facing wall 
-
 var current_wall = 1
 var recent_wall = 0
-#could also instead keep a variable for the most recently touched wall, so that the player could jump off 
-#of two different walls that face the same direction that are just adjacent to each other. 
-#yea i think im gonna go with that one
+#region
 
 @onready var sprite: AnimatedSprite2D = $AnimatedSprite2D
 
 ## Use double hashtags for a "title comment", it looks a lil different!
 func _physics_process(delta):
-	# Add the gravity.
+	# Add the gravity, whenever the player is both not on the ground or clinging to a wall
 	if not is_on_floor() and not attached_to_wall:
 		velocity += get_gravity() * delta
-	elif is_on_floor_only():
+	# Reset double and wall jumps when the player hits the ground
+	elif is_on_floor():
 		double_jump_count = 0
 		
-#double jumps currently reset when the player wall jumps, we can change that. 
+
 
 	#Handle down, so far only used if the player wants to detach from a wall
 	if Input.is_action_just_pressed("Down") and attached_to_wall:
@@ -40,36 +36,34 @@ func _physics_process(delta):
 		if is_on_floor():
 			velocity.y = JUMP_VELOCITY
 			recent_wall = null
-	
 		
+		#if clinging to a wall
 		elif attached_to_wall:
-			
 			velocity.y = JUMP_VELOCITY
 			attached_to_wall = false
 			recent_wall = current_wall
 			current_wall = null
 		
-			
+		#if going to cling to a wall
 		elif is_on_wall():
-			#print(position.x)
 			current_wall = int(position.x)
 			if recent_wall != current_wall:
-				#need to handle it so there can only be one wall jump on a single wall at a time
 				velocity.y = 0
-				#set current wall to the wall the player is currently on 
-				
-				print(current_wall)
 				attached_to_wall = true
 				
+		#if going to use a double jump
 		elif double_jump_count == 0:
 			velocity.y = JUMP_VELOCITY
 			double_jump_count += 1
+			
+		#(all other cases, no jump is performed)
 		
 	if Input.is_action_just_released("Accept") and velocity.y < -60:
 		velocity.y = - 60
 
 	# Get the input direction and handle the movement/deceleration.
 	var direction = Input.get_axis("Left", "Right")
+	#only walk when there is a direction input and the player is not clinging to a wall
 	if direction and not attached_to_wall:
 		if sprite.animation != "walk":
 			sprite.play("walk")  # Play the running animation

--- a/band_together/entities/player/player.gd
+++ b/band_together/entities/player/player.gd
@@ -31,17 +31,26 @@ func _physics_process(delta):
 	if Input.is_action_just_pressed("Accept"):
 		if is_on_floor():
 			velocity.y = JUMP_VELOCITY
+			recent_wall = null
+	
 		
 		elif attached_to_wall:
-			recent_wall = current_wall
+			
 			velocity.y = JUMP_VELOCITY
 			attached_to_wall = false
+			recent_wall = current_wall
+			current_wall = null
+		
 			
 		elif is_on_wall():
+			#print(position.x)
+			current_wall = int(position.x)
 			if recent_wall != current_wall:
 				#need to handle it so there can only be one wall jump on a single wall at a time
 				velocity.y = 0
 				#set current wall to the wall the player is currently on 
+				
+				print(current_wall)
 				attached_to_wall = true
 				
 		elif double_jump_count == 0:

--- a/band_together/project.godot
+++ b/band_together/project.godot
@@ -25,6 +25,10 @@ window/size/window_height_override=1440
 window/stretch/mode="canvas_items"
 window/stretch/scale_mode="integer"
 
+[dotnet]
+
+project/assembly_name="Band Together"
+
 [file_customization]
 
 folder_colors={

--- a/band_together/scenes/main_menu.gd
+++ b/band_together/scenes/main_menu.gd
@@ -12,7 +12,7 @@ func _process(delta: float) -> void:
 
 
 func _on_start_pressed() -> void:
-	get_tree().change_scene_to_file("res://scenes/test/test_helen.tscn")
+	get_tree().change_scene_to_file("res://scenes/test/test_walljump.tscn")
 
 
 func _on_options_pressed() -> void:

--- a/band_together/scenes/test/test_walljump.tscn
+++ b/band_together/scenes/test/test_walljump.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=4 uid="uid://1eb4wwhk7xcb"]
+[gd_scene load_steps=9 format=4 uid="uid://1eb4wwhk7xcb"]
 
 [ext_resource type="Texture2D" uid="uid://da6a4a38e1tul" path="res://Environment/Tiles-DELETE.png" id="1_ae3vf"]
 [ext_resource type="PackedScene" uid="uid://chmdbpxvcc4i8" path="res://entities/player/player.tscn" id="2_dmefx"]
@@ -130,6 +130,8 @@ sources/1 = SubResource("TileSetAtlasSource_yw07a")
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_u5j86"]
 size = Vector2(24.75, 129)
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_mkr4o"]
+
 [node name="Node2D" type="Node2D"]
 
 [node name="Wall" type="TileMapLayer" parent="."]
@@ -142,9 +144,8 @@ tile_set = SubResource("TileSet_dcilm")
 position = Vector2(176, 63)
 shape = SubResource("RectangleShape2D_u5j86")
 
-[node name="CollisionShape2D2" type="CollisionShape2D" parent="Wall/Area2D"]
-position = Vector2(239.625, 89)
-shape = SubResource("RectangleShape2D_u5j86")
+[node name="2" type="CollisionShape2D" parent="Wall/Area2D"]
+shape = SubResource("RectangleShape2D_mkr4o")
 
 [node name="Ground" type="TileMapLayer" parent="."]
 tile_map_data = PackedByteArray("AAAAAAQAAQABAAAAAAAAAAUAAQABAAEAAAACAAQAAQACAAAAAAACAAUAAQACAAEAAAADAAQAAQACAAAAAAADAAUAAQACAAEAAAAEAAQAAQACAAAAAAAEAAUAAQACAAEAAAAFAAQAAQACAAAAAAAFAAUAAQACAAEAAAAGAAQAAQACAAAAAAAGAAUAAQACAAEAAAAHAAQAAQACAAAAAAAHAAUAAQACAAEAAAAIAAQAAQACAAAAAAAIAAUAAQACAAEAAAAJAAQAAQADAAAAAAAJAAUAAQADAAEAAAABAAQAAQACAAAAAAABAAUAAQACAAEAAAA=")

--- a/band_together/scenes/test/test_walljump.tscn
+++ b/band_together/scenes/test/test_walljump.tscn
@@ -1,0 +1,189 @@
+[gd_scene load_steps=7 format=4 uid="uid://1eb4wwhk7xcb"]
+
+[ext_resource type="Texture2D" uid="uid://da6a4a38e1tul" path="res://Environment/Tiles-DELETE.png" id="1_ae3vf"]
+[ext_resource type="PackedScene" uid="uid://chmdbpxvcc4i8" path="res://entities/player/player.tscn" id="2_dmefx"]
+[ext_resource type="Script" path="res://entities/player/player.gd" id="3_0hdly"]
+[ext_resource type="Texture2D" uid="uid://ijjot86jaukj" path="res://assets/health/heart.png" id="4_il00e"]
+
+[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_yw07a"]
+texture = ExtResource("1_ae3vf")
+texture_region_size = Vector2i(32, 32)
+1:2/0 = 0
+1:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+2:2/0 = 0
+2:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+3:2/0 = 0
+3:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+8:2/0 = 0
+8:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+8:1/0 = 0
+8:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+7:1/0 = 0
+1:3/0 = 0
+1:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+2:3/0 = 0
+2:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+3:3/0 = 0
+3:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+0:4/0 = 0
+0:4/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+1:4/0 = 0
+1:4/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+2:4/0 = 0
+2:4/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+3:4/0 = 0
+3:4/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+4:4/0 = 0
+4:4/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+4:5/0 = 0
+4:5/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+3:5/0 = 0
+3:5/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+2:5/0 = 0
+2:5/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+1:5/0 = 0
+1:5/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+0:5/0 = 0
+0:5/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+1:6/0 = 0
+1:6/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+2:6/0 = 0
+2:6/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+3:6/0 = 0
+3:6/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+5:6/0 = 0
+5:5/0 = 0
+6:5/0 = 0
+6:6/0 = 0
+7:6/0 = 0
+8:6/0 = 0
+8:5/0 = 0
+7:5/0 = 0
+9:5/0 = 0
+9:6/0 = 0
+8:4/0 = 0
+7:4/0 = 0
+6:4/0 = 0
+6:8/0 = 0
+7:8/0 = 0
+7:7/0 = 0
+8:7/0 = 0
+9:8/0 = 0
+9:7/0 = 0
+8:8/0 = 0
+10:8/0 = 0
+10:9/0 = 0
+9:9/0 = 0
+8:9/0 = 0
+7:9/0 = 0
+6:9/0 = 0
+6:10/0 = 0
+7:10/0 = 0
+8:10/0 = 0
+9:10/0 = 0
+10:10/0 = 0
+9:11/0 = 0
+8:11/0 = 0
+7:11/0 = 0
+5:10/0 = 0
+5:9/0 = 0
+4:10/0 = 0
+3:10/0 = 0
+2:10/0 = 0
+3:9/0 = 0
+2:9/0 = 0
+4:9/0 = 0
+4:8/0 = 0
+4:7/0 = 0
+5:7/0 = 0
+5:8/0 = 0
+3:8/0 = 0
+3:7/0 = 0
+2:7/0 = 0
+2:8/0 = 0
+1:7/0 = 0
+0:7/0 = 0
+0:8/0 = 0
+1:8/0 = 0
+1:9/0 = 0
+0:9/0 = 0
+1:0/next_alternative_id = 2
+1:0/0 = 0
+1:0/1 = 1
+1:1/next_alternative_id = 2
+1:1/0 = 0
+1:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+1:1/1 = 1
+2:0/0 = 0
+2:1/0 = 0
+2:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+3:0/0 = 0
+3:1/0 = 0
+3:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+
+[sub_resource type="TileSet" id="TileSet_dcilm"]
+tile_size = Vector2i(32, 32)
+physics_layer_0/collision_layer = 4
+physics_layer_0/collision_mask = 0
+sources/1 = SubResource("TileSetAtlasSource_yw07a")
+
+[node name="Node2D" type="Node2D"]
+
+[node name="Wall" type="TileMapLayer" parent="."]
+tile_map_data = PackedByteArray("AAAAAAQAAQABAAAAAAAAAAUAAQABAAEAAAACAAQAAQACAAAAAAACAAUAAQACAAEAAAADAAQAAQACAAAAAAADAAUAAQACAAEAAAAEAAQAAQACAAAAAAAEAAUAAQACAAEAAAAFAAQAAQACAAAAAAAFAAUAAQACAAEAAAAGAAQAAQACAAAAAAAGAAUAAQACAAEAAAAHAAQAAQAIAAIAAAAHAAUAAQACAAEAAAAIAAQAAQACAAAAAAAIAAUAAQACAAEAAAAJAAQAAQADAAAAAAAJAAUAAQADAAEAAAABAAQAAQACAAAAAAABAAUAAQACAAEAAAAHAAMAAQAIAAEAAAAHAAIAAQAIAAEAAAAHAAEAAQAIAAEAAAAHAAAAAQAIAAEAAAAFAAMAAQAIAAEAAAAFAAIAAQAIAAEAAAAFAAEAAQAIAAEAAAAFAAAAAQAIAAEAAAA=")
+tile_set = SubResource("TileSet_dcilm")
+
+[node name="Ground" type="TileMapLayer" parent="."]
+tile_map_data = PackedByteArray("AAAAAAQAAQABAAAAAAAAAAUAAQABAAEAAAACAAQAAQACAAAAAAACAAUAAQACAAEAAAADAAQAAQACAAAAAAADAAUAAQACAAEAAAAEAAQAAQACAAAAAAAEAAUAAQACAAEAAAAFAAQAAQACAAAAAAAFAAUAAQACAAEAAAAGAAQAAQACAAAAAAAGAAUAAQACAAEAAAAHAAQAAQACAAAAAAAHAAUAAQACAAEAAAAIAAQAAQACAAAAAAAIAAUAAQACAAEAAAAJAAQAAQADAAAAAAAJAAUAAQADAAEAAAABAAQAAQACAAAAAAABAAUAAQACAAEAAAA=")
+tile_set = SubResource("TileSet_dcilm")
+
+[node name="Player" parent="." instance=ExtResource("2_dmefx")]
+position = Vector2(32, 135)
+scale = Vector2(0.68558, 0.601599)
+collision_layer = 2
+collision_mask = 12
+script = ExtResource("3_0hdly")
+
+[node name="UI" type="CanvasLayer" parent="."]
+
+[node name="Hearts" type="Panel" parent="UI"]
+self_modulate = Color(1, 1, 1, 0)
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -72.0
+offset_bottom = 24.0
+grow_horizontal = 0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="UI/Hearts"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -28.0
+offset_top = -8.0
+offset_right = 28.0
+offset_bottom = 8.0
+grow_horizontal = 2
+grow_vertical = 2
+alignment = 2
+
+[node name="Heart" type="TextureRect" parent="UI/Hearts/HBoxContainer"]
+texture_filter = 1
+layout_mode = 2
+texture = ExtResource("4_il00e")
+expand_mode = 2
+
+[node name="Heart2" type="TextureRect" parent="UI/Hearts/HBoxContainer"]
+texture_filter = 1
+layout_mode = 2
+texture = ExtResource("4_il00e")
+expand_mode = 2
+
+[node name="Heart3" type="TextureRect" parent="UI/Hearts/HBoxContainer"]
+texture_filter = 1
+layout_mode = 2
+texture = ExtResource("4_il00e")
+expand_mode = 2

--- a/band_together/scenes/test/test_walljump.tscn
+++ b/band_together/scenes/test/test_walljump.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=4 uid="uid://1eb4wwhk7xcb"]
+[gd_scene load_steps=8 format=4 uid="uid://1eb4wwhk7xcb"]
 
 [ext_resource type="Texture2D" uid="uid://da6a4a38e1tul" path="res://Environment/Tiles-DELETE.png" id="1_ae3vf"]
 [ext_resource type="PackedScene" uid="uid://chmdbpxvcc4i8" path="res://entities/player/player.tscn" id="2_dmefx"]
@@ -127,11 +127,24 @@ physics_layer_0/collision_layer = 4
 physics_layer_0/collision_mask = 0
 sources/1 = SubResource("TileSetAtlasSource_yw07a")
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_u5j86"]
+size = Vector2(24.75, 129)
+
 [node name="Node2D" type="Node2D"]
 
 [node name="Wall" type="TileMapLayer" parent="."]
 tile_map_data = PackedByteArray("AAAAAAQAAQABAAAAAAAAAAUAAQABAAEAAAACAAQAAQACAAAAAAACAAUAAQACAAEAAAADAAQAAQACAAAAAAADAAUAAQACAAEAAAAEAAQAAQACAAAAAAAEAAUAAQACAAEAAAAFAAQAAQACAAAAAAAFAAUAAQACAAEAAAAGAAQAAQACAAAAAAAGAAUAAQACAAEAAAAHAAQAAQAIAAIAAAAHAAUAAQACAAEAAAAIAAQAAQACAAAAAAAIAAUAAQACAAEAAAAJAAQAAQADAAAAAAAJAAUAAQADAAEAAAABAAQAAQACAAAAAAABAAUAAQACAAEAAAAHAAMAAQAIAAEAAAAHAAIAAQAIAAEAAAAHAAEAAQAIAAEAAAAHAAAAAQAIAAEAAAAFAAMAAQAIAAEAAAAFAAIAAQAIAAEAAAAFAAEAAQAIAAEAAAAFAAAAAQAIAAEAAAA=")
 tile_set = SubResource("TileSet_dcilm")
+
+[node name="Area2D" type="Area2D" parent="Wall"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Wall/Area2D"]
+position = Vector2(176, 63)
+shape = SubResource("RectangleShape2D_u5j86")
+
+[node name="CollisionShape2D2" type="CollisionShape2D" parent="Wall/Area2D"]
+position = Vector2(239.625, 89)
+shape = SubResource("RectangleShape2D_u5j86")
 
 [node name="Ground" type="TileMapLayer" parent="."]
 tile_map_data = PackedByteArray("AAAAAAQAAQABAAAAAAAAAAUAAQABAAEAAAACAAQAAQACAAAAAAACAAUAAQACAAEAAAADAAQAAQACAAAAAAADAAUAAQACAAEAAAAEAAQAAQACAAAAAAAEAAUAAQACAAEAAAAFAAQAAQACAAAAAAAFAAUAAQACAAEAAAAGAAQAAQACAAAAAAAGAAUAAQACAAEAAAAHAAQAAQACAAAAAAAHAAUAAQACAAEAAAAIAAQAAQACAAAAAAAIAAUAAQACAAEAAAAJAAQAAQADAAAAAAAJAAUAAQADAAEAAAABAAQAAQACAAAAAAABAAUAAQACAAEAAAA=")


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] UI/UX improvement

## Description
Implemented the wall jump movement mechanic to be associated with the violin. 

## Testing
Testing was all done manually. I exhausted as many scenarios as I could think of. i.e, trying to wall jump on the same wall twice in a row. Double jumping before and after a wall jump. Wall jumping between two different walls, wall jumping while on the ground, etc 

## Screenshots (If Applicable)
Player can now press the jump button while in the air facing a wall to cling to it. In this state, player cannot move horizontally, and may detach from the wall by pressing down. The player can press jump again, combined with a directional input to jump off of the wall. Players cannot wall jump off the same wall twice, and wall jumps/ double jumps only refresh completely when the player hits the ground. 

## Checklist
- [x] I have run the branch locally and tested the changes.
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation, if applicable.
- [x] My changes generate no new warnings 
