### PR TITLE
Added weapon swapping and some bugfixes

### DIFF
--- a/band_together/entities/player/player.tscn
+++ b/band_together/entities/player/player.tscn
@@ -112,12 +112,13 @@ animations = [{
 }]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_2u0e4"]
-radius = 18.0
+radius = 20.025
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_b5c5w"]
 size = Vector2(32.75, 25)
 
 [node name="Player" type="CharacterBody2D"]
+collision_layer = 2
 safe_margin = 0.1
 script = ExtResource("1_mms2d")
 
@@ -190,6 +191,7 @@ stream = ExtResource("6_jgj6o")
 
 [node name="DrumJump" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource("7_6icqt")
+volume_db = -3.5
 
 [node name="ViolinJump" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource("8_3mujn")

--- a/band_together/project.godot
+++ b/band_together/project.godot
@@ -69,7 +69,7 @@ project/assembly_name="Band Together"
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/dialogic/plugin.cfg")
+enabled=PackedStringArray()
 
 [file_customization]
 
@@ -142,16 +142,6 @@ Pause={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":6,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
-Baton={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":77,"key_label":0,"unicode":109,"location":0,"echo":false,"script":null)
-]
-}
-Drum={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":78,"key_label":0,"unicode":110,"location":0,"echo":false,"script":null)
-]
-}
 dialogic_default_action={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194309,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
@@ -159,6 +149,18 @@ dialogic_default_action={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":88,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
+]
+}
+CycleR={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":5,"axis_value":1.0,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
+]
+}
+CycleL={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":4,"axis_value":1.0,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/band_together/scenes/game_manager.gd
+++ b/band_together/scenes/game_manager.gd
@@ -1,9 +1,40 @@
 extends Node
 
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
-	pass
+var instruments_list: Array[String] = ["baton", "drum", "sax", "violin"]
+var drum_unlocked: bool = true
+var sax_unlocked: bool = false
+var violin_unlocked: bool = false
+var current_instrument: int = 0  # Array index of instruments_list
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(_delta: float) -> void:
-	pass
+
+func get_current_instrument() -> String:
+	return instruments_list[current_instrument]
+	
+## Cycles through instruments based on cycle_dir (1 for right, -1 for left)
+func set_current_instrument(cycle_dir: int) -> void:
+	# Sets the value of current_instrument to an array index for the instrument
+	# to equip. Checks if instrument is unlocked then adjusts
+	var new_instrument: int = current_instrument
+	for i in range(4):
+		# Could have used a while loop, but this is guaranteed faster!
+		new_instrument = (new_instrument + cycle_dir + 4) % 4
+		# ^ +4 because godot modulo doesn't work on negatives ??
+		if is_instrument_unlocked(new_instrument):
+			current_instrument = new_instrument
+			break  # Do not keep cycling if instrument is good
+		# Else we want to keep cycling left or right until we have an unlocked!
+
+## Helper for set_current_instrument, returns if instrument at index is unlocked
+func is_instrument_unlocked(index: int) -> bool:
+	match index:
+		0:
+			return true
+		1:
+			return drum_unlocked
+		2:
+			return sax_unlocked
+		3:
+			return violin_unlocked
+		_:
+			print_debug("is_instrument_unlocked: index greater than 3 or less than 0. How did you even get here?")
+			return false

--- a/band_together/scenes/test/test_jon.tscn
+++ b/band_together/scenes/test/test_jon.tscn
@@ -133,7 +133,6 @@ tile_set = SubResource("TileSet_dcilm")
 [node name="Player" parent="." instance=ExtResource("2_148ad")]
 position = Vector2(32, 135)
 scale = Vector2(0.68558, 0.601599)
-collision_layer = 2
 collision_mask = 4
 left_limit = 0
 bottom_limit = 192


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] UI/UX improvement

## Description
- Fixed bug in player's coyote time code allowing extra double jumps in certain situations.
- Fixed bug in player's wall-jump code allowing triple jump if you begin sliding then disconnect from wall without jumping
- Turned down double jump drum sound effect
- Changed player and DrumAttack collision layers/masks to match other game objects
- Added DrumKnockback collision box on player, which is larger and activates at the same time as DrumAttack
- Added "CycleR" and "CycleL" buttons to game config, currently set to A for left and S for right on keyboard, or the triggers on gamepad. This can be used for weapon swaps.
- Added current_instrument to player to cycle through currently equipped instrument. Current instrument getters and setters are in the GameManager script so it persists between scenes.
- Added checks for just double jump currently, you can now only double jump if **drum_unlocked == true** in the GameManager script, similar practice can be used for dashing and wall jumping. (see line 164 of player.gd)
- Removed input action "Drum" in anticipation of putting all abilities on the same button. This currently throws many errors when the game is running, but is not game-breaking. Will be fixed soon!

## Testing
Used print statements to ensure my weapon swapping function worked correctly. Tested that bugs were fixed by playing in a test scene.

## Screenshots (If Applicable)
Screenshot of functions in game_manager.gd:
![image](https://github.com/user-attachments/assets/18510653-b15d-4936-98eb-43f5ed599eae)

## Additional Information
- Make sure we use print_debug() instead of print() in the future, as print() can be seen in the full game's release through a terminal!
- Instrument booleans and swapping is kept in GameManager so it persists between scene changes thanks to autoload.

## Checklist
- [x] I have run the branch locally and tested the changes.
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation, if applicable.
- [x] My changes generate no new warnings 
