### PR TITLE
Added easy mode, speedrun timer, and some other stuff!

### DIFF
--- a/band_together/dialogic timelines/prologue.dtl
+++ b/band_together/dialogic timelines/prologue.dtl
@@ -4,5 +4,5 @@ allegro: Let's see. What can I last remember?
 allegro: The Band was boarding a ship to sail to the Kingdom of Paladi, and then...
 allegro: I think I remember… a rough storm. The ship must have gotten into a terrible wreck on the way.
 allegro: That would explain why I am on a beach.
-allegro: But where is everyone? I should go look for them… I’m not sure what to do without them. 
+allegro: But where is everyone? I should go look for them… I’m not sure what to do without them.
 do GameManager.dialogic_signal_end()

--- a/band_together/project.godot
+++ b/band_together/project.godot
@@ -28,11 +28,10 @@ Dialogic="*res://addons/dialogic/Core/DialogicGameHandler.gd"
 [dialogic]
 
 directories/dch_directory={
-"Arco": "res://dialogic timelines/arco.dch",
+"AAAAAAAAAA": "res://dialogic timelines/Arco.dch",
 "allegro": "res://allegro.dch",
 "arco": "res://dialogic timelines/arco.dch",
 "breve": "res://dialogic timelines/breve.dch",
-"dialogic timelines/Arco": "res://dialogic timelines/Arco.dch",
 "forte": "res://dialogic timelines/forte.dch",
 "ghost": "res://ghost.dch"
 }
@@ -133,6 +132,14 @@ theme/custom_font="res://assets/GrapeSoda.ttf"
 
 [input]
 
+ui_accept={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194309,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194310,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":true,"script":null)
+]
+}
 ui_cancel={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194305,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)

--- a/band_together/scenes/interfaces/main_menu/main_menu.gd
+++ b/band_together/scenes/interfaces/main_menu/main_menu.gd
@@ -8,10 +8,27 @@ func _ready():
 	print_debug("loading...")
 	await GameManager.load_game()
 	print_debug("loaded!")
+	
+	# Set window visual settings
+	GameManager.set_screen_resolution()
+	GameManager.set_screen_mode()
+	
+	
 	if GameManager.new_game:
 		start_game_btn.text = "New Game"
 	else:
 		start_game_btn.text = "Continue"
+	if GameManager.speedrun_mode:
+		$SpeedrunTimer.visible = true
+		if GameManager.best_time >= 3600:
+			# Longer than an hour
+			$SpeedrunTimer/BestTime.text = "%02d:%02d:%02d" % GameManager.get_time(GameManager.best_time)
+		else:
+			$SpeedrunTimer/BestTime.text = "%02d:%02d" % [GameManager.get_time(GameManager.best_time)[1], GameManager.get_time(GameManager.best_time)[2]]
+		var ms = "%.3f" % snapped(GameManager.best_time-int(GameManager.best_time), 0.001)
+		$SpeedrunTimer/BestTimeMS.text = ms.substr(1)
+	else:
+		$SpeedrunTimer.visible = false
 	
 	# This next part fixes the bug where player gets stuck when quitting during dialogues
 	# I really hope this doesn't create more bugs lol

--- a/band_together/scenes/interfaces/main_menu/main_menu.tscn
+++ b/band_together/scenes/interfaces/main_menu/main_menu.tscn
@@ -273,6 +273,33 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_f0yxt")
 theme_override_styles/normal = SubResource("StyleBoxFlat_7fy76")
 text = "Quit"
 
+[node name="SpeedrunTimer" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -66.0
+offset_top = -40.0
+offset_right = 66.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_constants/separation = 0
+
+[node name="BestTimeTitle" type="Label" parent="SpeedrunTimer"]
+layout_mode = 2
+text = "Fastest Run: "
+
+[node name="BestTime" type="Label" parent="SpeedrunTimer"]
+layout_mode = 2
+text = "00:00"
+
+[node name="BestTimeMS" type="Label" parent="SpeedrunTimer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 0.486275)
+text = ".000"
+
 [connection signal="pressed" from="VBoxContainer/StartGame" to="." method="_on_start_pressed"]
 [connection signal="pressed" from="VBoxContainer/Reset Game" to="." method="_on_reset_game_pressed"]
 [connection signal="pressed" from="VBoxContainer/Settings" to="." method="_on_options_pressed"]

--- a/band_together/scenes/interfaces/main_menu/settings_menu.tscn
+++ b/band_together/scenes/interfaces/main_menu/settings_menu.tscn
@@ -107,14 +107,14 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -50.0
-offset_top = -45.0
-offset_right = 50.0
-offset_bottom = 51.0
+offset_left = -95.5
+offset_top = -55.765
+offset_right = 95.5
+offset_bottom = 77.235
 grow_horizontal = 2
 grow_vertical = 2
 focus_mode = 2
-theme_override_constants/separation = 4
+theme_override_constants/separation = 1
 
 [node name="Reset Game" type="Button" parent="VBoxContainer"]
 layout_mode = 2
@@ -172,6 +172,14 @@ popup/item_1/id = 1
 popup/item_2/text = "Fullscreen"
 popup/item_2/id = 2
 
+[node name="EasyMode" type="CheckButton" parent="VBoxContainer"]
+layout_mode = 2
+text = "Easy Mode (0 damage)"
+
+[node name="Speedrun Mode" type="CheckButton" parent="VBoxContainer"]
+layout_mode = 2
+text = "Speedrun Timer"
+
 [node name="Return" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
@@ -184,10 +192,12 @@ theme_override_styles/focus = SubResource("StyleBoxFlat_6yywy")
 theme_override_styles/hover = SubResource("StyleBoxFlat_6yywy")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_f0yxt")
 theme_override_styles/normal = SubResource("StyleBoxFlat_7fy76")
-text = "Save And Return"
+text = "Return"
 
 [connection signal="pressed" from="VBoxContainer/Reset Game" to="." method="_on_reset_game_pressed"]
 [connection signal="timeout" from="VBoxContainer/Reset Game/AreYouSureTimer" to="." method="_on_are_you_sure_timer_timeout"]
 [connection signal="item_selected" from="VBoxContainer/Resolution/ResoDropdown" to="." method="_on_reso_dropdown_item_selected"]
 [connection signal="item_selected" from="VBoxContainer/WindowMode/WMDropdown" to="." method="_on_wm_dropdown_item_selected"]
+[connection signal="toggled" from="VBoxContainer/EasyMode" to="." method="_on_easy_mode_toggled"]
+[connection signal="toggled" from="VBoxContainer/Speedrun Mode" to="." method="_on_speedrun_mode_toggled"]
 [connection signal="pressed" from="VBoxContainer/Return" to="." method="_on_return_pressed"]

--- a/band_together/scenes/scene_transition/screen_transition.gd
+++ b/band_together/scenes/scene_transition/screen_transition.gd
@@ -10,7 +10,10 @@ func _ready() -> void:
 	pass
 
 func change_scene(target_scene: String):
-	 # A higher value ensures it's rendered on top of other scenes/nodes
+	Engine.time_scale = 1  # Stops game from being weird if quit during hitfreeze, may cause other issues!!
+	UI.increment_speedrun_timer = false
+	await GameManager.save_game()  # Save before transitioning (whoops)
+	# A higher value ensures it's rendered on top of other scenes/nodes
 	transitioning = true
 	canvas_layer.layer = 10 
 	var old_scene = get_tree().current_scene
@@ -21,11 +24,12 @@ func change_scene(target_scene: String):
 	
 	while get_tree().current_scene == null or get_tree().current_scene == old_scene:
 		await get_tree().process_frame  # Wait 1 frame for assignment
-	await GameManager.save_game()
+	
 	UI.reset()
 	animation_player.play("transition_out")
 	await animation_player.animation_finished
 	transitioning = false
+	# Do not need to turn the speedrun timer back on. That is handled by UI.reset()
 	
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta: float) -> void:

--- a/band_together/scenes/ui.tscn
+++ b/band_together/scenes/ui.tscn
@@ -327,6 +327,21 @@ stream = ExtResource("7_wcc2y")
 stream = ExtResource("8_74hw7")
 volume_db = -7.0
 
+[node name="SpeedrunTimer" type="HBoxContainer" parent="."]
+offset_left = 8.225
+offset_right = 143.31
+offset_bottom = 25.45
+theme_override_constants/separation = 0
+
+[node name="BestTime" type="Label" parent="SpeedrunTimer"]
+layout_mode = 2
+text = "00:00"
+
+[node name="BestTimeMS" type="Label" parent="SpeedrunTimer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 0.698039)
+text = ".000"
+
 [connection signal="pressed" from="PausePanel/VBoxContainer/Resume" to="." method="_on_resume_pressed"]
 [connection signal="pressed" from="PausePanel/VBoxContainer/Reset" to="." method="_on_reset_pressed"]
 [connection signal="pressed" from="PausePanel/VBoxContainer/MainMenu" to="." method="_on_main_menu_pressed"]


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [x] UI/UX improvement

## Description
- Added controller support for settings menu including autofocus and dropdowns
- Settings were not saving correctly. Now saves the game upon settings being set.
- "Save and Return" changed to "Return"
- Recreated arco.dch to try to fix Arco/arco issue, unfortunately I think it is a dialogic bug and cannot be fixed unless we reinstall the entire plugin
	- However, Arco's picture is back in dialogues
- Added "Speedrun mode" Where a timer would show up in the UI if enabled
	- If enabled, main menu would show the best playtime at the bottom
	- Note that in order for this timer to work correctly, it will always be calculating your time, just will hide it if speedrun mode is disabled
	- Speedrun timer will always be counting, but pauses if the player is on the main menu, settings, death, win screens, or pause menu, or is loading a scene
- Added "Easy mode" which stops player from taking damage when hit (still knocks back, just health is not subtracted)
- Fixed bug where game was not starting in user-set resolution or window mode by setting them in the ready() function of main_menu (should be the only screen players can access upon first opening the exe)
- Fixed loading screen bug, game should save before loading next scene, not after.

## Testing
Played through the game, ensuring to test quitting to main menu, resetting the game, restarting levels, the beginning and ends of the game and how they behave with the speedrun timer.

## Additional information
Since I added more saved settings, you will probably once again need to delete your save file in `C:\Users\<YOUR USERNAME>\AppData\Roaming\Godot\app_userdata\Band Together` to open the game properly

## Checklist
- [x] I have run the branch locally and tested the changes.
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation, if applicable.
- [x] My changes generate no new warnings 
